### PR TITLE
Evita overflow horizontal sem usar overflow hidden

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -7,8 +7,8 @@
 .menugpix-overlay {
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   background-color: rgba(255,255,255,0.1);
   z-index: 999;
   -webkit-backdrop-filter: blur(7px);

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -1,13 +1,13 @@
 /* ===== HERO FULL-BLEED ===== */
-/* Esta classe ignora o container do <main> e ocupa 100vw. */
+/* Esta classe ocupa 100% da largura do container para evitar overflow horizontal. */
 .hero-fullbleed{
   position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
   width: 100%;
-  padding: 0px;
+  padding: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Controla a “duração” da rolagem do efeito */
@@ -22,7 +22,7 @@
   position: sticky;
   top: 0;
   left: 0;
-  width: 100vw;   /* 100% da largura da viewport */
+  width: 100%;   /* 100% da largura da viewport */
   height: 100vh;  /* 100% da altura da viewport */
   display: block;
    max-width: 100% !important; /* impede restrição de container */

--- a/assets/css/sessao6.css
+++ b/assets/css/sessao6.css
@@ -164,10 +164,9 @@
   .sessao-6-bloco-grande{
     grid-column:1/-1; background:transparent !important; box-shadow:none !important; min-height:0;
   }
-  .s6-galeria-mobile{ display:flex; flex-direction:column; gap:0;
-    margin-left:calc(50% - 50vw); margin-right:calc(50% - 50vw); }
+  .s6-galeria-mobile{ display:flex; flex-direction:column; gap:0; }
   .s6-gal-item{ border-radius:0; box-shadow:none; overflow:hidden; background:transparent; }
-  .s6-gal-img{ display:block; width:100vw; height:auto; }
+  .s6-gal-img{ display:block; width:100%; height:auto; }
   .s6-gal-cap{ display:none; }
 
   .sessao-6-seta-navegacao{ width:44px; height:44px; }


### PR DESCRIPTION
## Summary
- Ajusta largura do overlay e canvas para 100% evitando barra de rolagem horizontal
- Remove margens negativas e imagens em 100vw na galeria móvel da sessão 6
- Simplifica hero section para ocupar apenas a largura do container

## Testing
- `php -l index.php`
- `php -l paginas/home.php`


------
https://chatgpt.com/codex/tasks/task_e_68b4e5b69cec832e95a943288958bd29